### PR TITLE
Fix channel link formatting

### DIFF
--- a/lib/rich-message.js
+++ b/lib/rich-message.js
@@ -39,7 +39,7 @@ function makeRichMessage (message, username) {
   message.html = md.render(message.text)
   message.html = message.html.replace(/\n/g, '<p></p>')
   message.html = ghlink(message.html, { format: 'html' })
-  message.html = message.html.replace(/(^| )(#[a-zA-Z0-9]+)( |$)$/g, '$1<a href="$2">$2</a>$3')
+  message.html = message.html.replace(/([> ])(#[a-zA-Z0-9]+)([ <])/g, '$1<a href="$2">$2</a>$3')
 
   var highlight = (message.text.indexOf(username) !== -1)
   var classStr = highlight ? ' class="highlight"' : ''


### PR DESCRIPTION
This makes channel names clickable again. Since messages are wrapped in p-tags the old one wouldn't match.
