### PR TITLE
Add tests and update link regex

### DIFF
--- a/lib/rich-message.js
+++ b/lib/rich-message.js
@@ -39,7 +39,7 @@ function makeRichMessage (message, username) {
   message.html = md.render(message.text)
   message.html = message.html.replace(/\n/g, '<p></p>')
   message.html = ghlink(message.html, { format: 'html' })
-  message.html = message.html.replace(/([> ])(#[a-zA-Z0-9]+)([ <])/g, '$1<a href="$2">$2</a>$3')
+  message.html = message.html.replace(/([> ])(#[a-zA-Z0-9]+)/g, '$1<a href="$2">$2</a>')
 
   var highlight = (message.text.indexOf(username) !== -1)
   var classStr = highlight ? ' class="highlight"' : ''

--- a/lib/rich-message.js
+++ b/lib/rich-message.js
@@ -36,10 +36,11 @@ function makeRichMessage (message, username) {
     : 'https://github.com/' + message.username + '.png'
   message.timeago = util.timeago(message.timestamp)
 
+  message.text = message.text.replace(/(^|\s)(#[a-zA-Z0-9]+)(?=$|\s)/g,
+                                      '$1[$2]($2)')
   message.html = md.render(message.text)
   message.html = message.html.replace(/\n/g, '<p></p>')
   message.html = ghlink(message.html, { format: 'html' })
-  message.html = message.html.replace(/([> ])(#[a-zA-Z0-9]+)/g, '$1<a href="$2">$2</a>')
 
   var highlight = (message.text.indexOf(username) !== -1)
   var classStr = highlight ? ' class="highlight"' : ''

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "standard": "^3.7.2",
-    "tap-spec": "^3.0.0",
+    "tap-dot": "^1.0.0",
     "tape": "^4.0.0"
   },
   "homepage": "https://github.com/moose-team/rich-message",
@@ -30,7 +30,7 @@
     "url": "https://github.com/moose-team/rich-message.git"
   },
   "scripts": {
-    "test": "standard && tape test/*.js | tap-spec"
+    "test": "standard && tape test/*.js | tap-dot"
   },
   "dependencies": {
     "ghlink": "^0.1.2",

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,6 @@
 var test = require('tape')
 var richMessage = require('../')
+var mergeMessages = richMessage.mergeMessages
 
 test('link replacement', function (t) {
   var message = {
@@ -39,5 +40,103 @@ test('anon avatars', function (t) {
 
   var output = richMessage(message, 'other_cat')
   t.equal(output.avatar, 'static/cat.png')
+  t.end()
+})
+
+test('github links', function (t) {
+  var message = {
+    text: 'cats isaacs/npm#1234',
+    username: 'cat',
+    timestamp: Date.now()
+  }
+
+  var output = richMessage(message, 'other_cat')
+  var expected = '<div><p>' +
+    'cats <a href="https://github.com/isaacs/npm/issues/1234">' +
+    'isaacs/npm#1234</a>' +
+   '</p><p></p></div>'
+
+  t.equal(output.html, expected)
+  t.end()
+})
+
+test('newlines -> paragraphs', function (t) {
+  var message = {
+    text: 'cat\ncat',
+    username: 'cat',
+    timestamp: Date.now()
+  }
+
+  var output = richMessage(message, 'other_cat')
+  var expected = '<div><p>' +
+    'cat<p></p>cat' +
+   '</p><p></p></div>'
+
+  t.equal(output.html, expected)
+  t.end()
+})
+
+test('username highlight', function (t) {
+  var message = {
+    text: 'cat',
+    username: 'cat',
+    timestamp: Date.now()
+  }
+
+  var output = richMessage(message, 'cat')
+  var expected = '<div class="highlight"><p>' +
+    'cat' +
+   '</p><p></p></div>'
+
+  t.equal(output.html, expected)
+  t.end()
+})
+
+test('timeago', function (t) {
+  var message = {
+    text: 'cat',
+    username: 'cat',
+    timestamp: 0
+  }
+
+  var output = richMessage(message, 'cat')
+  t.equal(output.timeago, '01/01/1970')
+  t.end()
+})
+
+test('markdown render', function (t) {
+  var message = {
+    text: '`cat` **cat**',
+    username: 'cat',
+    timestamp: Date.now()
+  }
+
+  var output = richMessage(message, 'other_cat')
+  var expected = '<div><p>' +
+    '<code>cat</code> <strong>cat</strong>' +
+   '</p><p></p></div>'
+
+  t.equal(output.html, expected)
+  t.end()
+})
+
+test('merge messages', function (t) {
+  var message1 = {
+    text: 'cat1',
+    html: '<p>cat1</p>'
+  }
+
+  var message2 = {
+    text: 'cat2',
+    html: '<p>cat2</p>'
+  }
+
+  var output = mergeMessages(message1, message2)
+  var expected = {
+    text: 'cat1\ncat2',
+    html: '<p>cat1</p><p></p><p>cat2</p>'
+  }
+
+  t.deepEqual(output, expected)
   t.end()
 })

--- a/test/index.js
+++ b/test/index.js
@@ -1,1 +1,19 @@
+var test = require('tape')
+var richMessage = require('../')
 
+test('link replacement', function (t) {
+  var message = {
+    text: '#cats #cats #cats not#cat',
+    username: 'cat',
+    timestamp: Date.now()
+  }
+
+  var output = richMessage(message, 'other_cat')
+  var expected = '<div><p>' +
+    '<a href="#cats">#cats</a> <a href="#cats">#cats</a> ' +
+    '<a href="#cats">#cats</a> not#cat' +
+    '</p><p></p></div>'
+
+  t.equal(output.html, expected)
+  t.end()
+})

--- a/test/index.js
+++ b/test/index.js
@@ -17,3 +17,27 @@ test('link replacement', function (t) {
   t.equal(output.html, expected)
   t.end()
 })
+
+test('github avatars', function (t) {
+  var message = {
+    text: 'i like cats',
+    username: 'cat',
+    timestamp: Date.now()
+  }
+
+  var output = richMessage(message, 'other_cat')
+  t.equal(output.avatar, 'https://github.com/cat.png')
+  t.end()
+})
+
+test('anon avatars', function (t) {
+  var message = {
+    text: 'i like cats',
+    username: 'Anonymous cat',
+    timestamp: Date.now()
+  }
+
+  var output = richMessage(message, 'other_cat')
+  t.equal(output.avatar, 'static/cat.png')
+  t.end()
+})

--- a/test/index.js
+++ b/test/index.js
@@ -4,7 +4,7 @@ var mergeMessages = richMessage.mergeMessages
 
 test('link replacement', function (t) {
   var message = {
-    text: '#cats #cats #cats not#cat',
+    text: '#cats #cats #cats not#cat #cat!%$',
     username: 'cat',
     timestamp: Date.now()
   }
@@ -12,7 +12,7 @@ test('link replacement', function (t) {
   var output = richMessage(message, 'other_cat')
   var expected = '<div><p>' +
     '<a href="#cats">#cats</a> <a href="#cats">#cats</a> ' +
-    '<a href="#cats">#cats</a> not#cat' +
+    '<a href="#cats">#cats</a> not#cat #cat!%$' +
     '</p><p></p></div>'
 
   t.equal(output.html, expected)


### PR DESCRIPTION
This adds tests for most of the rich-message functionality. I used tape since it was already added to package.json, but wouldn't take much time to change it if another framework is preferred.
#8 happens because the regex mathes overlap, this should fix it. This'll however turn the `#channel` part of `#channel!$#$#` into a link, but I'm not sure if that's a bad thing. If emoji channel names are to be supported it'd need an update though.
